### PR TITLE
Use classList to manipulate element classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Display timed notifications easy
     Jackbox.init(customSettings);
 </script>
 ```
+
+#### Browser support
+The file **jackbox.polyfill.js** can be used for modern browser support. 
+**IE8 and less**, needs to use polyfill for [Array.prototype.forEach](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Display timed notifications easy
     var customSettings = {
         notification: {
             time : 10, //in seconds, default is set to 5
-            classNames : "custom-class-name" //can be multiple
+            classNames : ["custom-class-name", "another-class-name"] //Array of classes
         }
     }
     Jackbox.init(customSettings);

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
 
   </section>
 
-<script src="jackbox.polyfill.js"></script>
+<script src="jackbox.polyfills.js"></script>
 <script src="jackbox.js"></script>
   <script>
     var customSettings = {

--- a/index.html
+++ b/index.html
@@ -65,14 +65,14 @@
     </footer>
 
   </section>
-  
+
 <script src="jackbox.polyfill.js"></script>
 <script src="jackbox.js"></script>
   <script>
     var customSettings = {
       notification:{
         time : 10,
-        classNames : "custom-class-name"
+        classNames : ["custom-class-name", "another-class-name"]
       }
     }
     Jackbox.init(customSettings);

--- a/index.html
+++ b/index.html
@@ -65,7 +65,8 @@
     </footer>
 
   </section>
-
+  
+<script src="jackbox.polyfill.js"></script>
 <script src="jackbox.js"></script>
   <script>
     var customSettings = {

--- a/jackbox.js
+++ b/jackbox.js
@@ -62,8 +62,9 @@
 
     var startCounter = function () {
       setTimeout(function () {
-        if (notification.className.indexOf("counting") === -1)
+        if (!notification.classList.contains("counting")){
           notification.classList.add("counting");
+        }
 
         timeout = window.setTimeout(purge, (ttl * 1000));
       }, 10);
@@ -81,7 +82,7 @@
     startCounter();
   }
 
-  lib.error = function (_message) {
+  lib.error = function (_message ) {
     createNotification(_message, "error");
   }
 

--- a/jackbox.js
+++ b/jackbox.js
@@ -11,7 +11,7 @@
   lib.init = function (customSettings) {
     lib.settings = Object.assign({}, lib.settings, customSettings);
     var wrapper = document.createElement("div");
-    wrapper.className = "notifications";
+    wrapper.classList.add("notifications");
     wrapper.id = "jackbox";
     window.document.body.appendChild(wrapper);
   }
@@ -26,19 +26,19 @@
     var ttl = lib.settings.notification.time;
     var timeout = null;
     
-    notification.className = "notification";
-    notification.className += " " + type;
+    notification.classList.add("notification");
+    notification.classList.add(type);
 
-    notification.className += " " + lib.settings.notification.classNames;
+    notification.classList.add(lib.settings.notification.classNames);
 
-    progress.className = "progress";
+    progress.classList.add("progress");
     progress.style.transitionDuration =  lib.settings.notification.time + "s";
 
     message.innerHTML = _message;
-    message.className = "message";
+    message.classList.add("message");
 
-    dismissButton.className = "dismiss"
-    icon.className = "icon"
+    dismissButton.classList.add("dismiss");
+    icon.classList.add("icon");
 
     notification.appendChild(progress);
     notification.appendChild(message);
@@ -46,7 +46,7 @@
     notification.appendChild(icon);
 
     var purge = function () {
-      notification.className = notification.className.replace("show", "");
+      notification.classList.remove("show");
       window.clearTimeout(timeout);
       setTimeout(function () {
         document.getElementById("jackbox").removeChild(notification);
@@ -54,14 +54,14 @@
     }
 
     var resetCounter = function () {
-      notification.className = notification.className.replace("counting", "");
+      notification.classList.remove("counting");
       window.clearTimeout(timeout);
     }
 
     var startCounter = function () {
       setTimeout(function () {
         if (notification.className.indexOf("counting") === -1)
-          notification.className += " counting";
+          notification.classList.add("counting");
 
         timeout = window.setTimeout(purge, (ttl * 1000));
       }, 10);
@@ -73,7 +73,7 @@
 
     document.getElementById("jackbox").appendChild(notification);
     setTimeout(function () {
-      notification.className += " show";
+      notification.classList.add("show");
     }, 10);
 
     startCounter();

--- a/jackbox.js
+++ b/jackbox.js
@@ -4,7 +4,7 @@
   lib.settings = {
     notification: {
       time: 5,
-      classNames: ""
+      classNames: []
     }
   }
 
@@ -28,8 +28,10 @@
     
     notification.classList.add("notification");
     notification.classList.add(type);
-
-    notification.classList.add(lib.settings.notification.classNames);
+  
+    lib.settings.notification.classNames.forEach(function (className){
+      notification.classList.add(className);
+    })
 
     progress.classList.add("progress");
     progress.style.transitionDuration =  lib.settings.notification.time + "s";

--- a/jackbox.polyfills.js
+++ b/jackbox.polyfills.js
@@ -236,4 +236,31 @@ if (objCtr.defineProperty) {
 }
 
 }
+/*Polyfill for Object.assign ES5 support
+* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+*/
+if (typeof Object.assign != 'function') {
+  (function () {
+    Object.assign = function (target) {
+      'use strict';
+      // We must check against these specific cases.
+      if (target === undefined || target === null) {
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var output = Object(target);
+      for (var index = 1; index < arguments.length; index++) {
+        var source = arguments[index];
+        if (source !== undefined && source !== null) {
+          for (var nextKey in source) {
+            if (source.hasOwnProperty(nextKey)) {
+              output[nextKey] = source[nextKey];
+            }
+          }
+        }
+      }
+      return output;
+    };
+  })();
+}
 } (window));

--- a/jackbox.polyfills.js
+++ b/jackbox.polyfills.js
@@ -1,0 +1,239 @@
+(function (window) {
+  /* 
+ * classList.js: Cross-browser full element.classList implementation.
+ * 2014-07-23
+ *
+ * By Eli Grey, http://eligrey.com
+ * Public Domain.
+ * NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+ */
+
+/*global self, document, DOMException */
+
+/*! @source http://purl.eligrey.com/github/classList.js/blob/master/classList.js*/
+
+if ("document" in self) {
+
+// Full polyfill for browsers with no classList support
+if (!("classList" in document.createElement("_"))) {
+
+(function (view) {
+
+"use strict";
+
+if (!('Element' in view)) return;
+
+var
+    classListProp = "classList"
+  , protoProp = "prototype"
+  , elemCtrProto = view.Element[protoProp]
+  , objCtr = Object
+  , strTrim = String[protoProp].trim || function () {
+    return this.replace(/^\s+|\s+$/g, "");
+  }
+  , arrIndexOf = Array[protoProp].indexOf || function (item) {
+    var
+        i = 0
+      , len = this.length
+    ;
+    for (; i < len; i++) {
+      if (i in this && this[i] === item) {
+        return i;
+      }
+    }
+    return -1;
+  }
+  // Vendors: please allow content code to instantiate DOMExceptions
+  , DOMEx = function (type, message) {
+    this.name = type;
+    this.code = DOMException[type];
+    this.message = message;
+  }
+  , checkTokenAndGetIndex = function (classList, token) {
+    if (token === "") {
+      throw new DOMEx(
+          "SYNTAX_ERR"
+        , "An invalid or illegal string was specified"
+      );
+    }
+    if (/\s/.test(token)) {
+      throw new DOMEx(
+          "INVALID_CHARACTER_ERR"
+        , "String contains an invalid character"
+      );
+    }
+    return arrIndexOf.call(classList, token);
+  }
+  , ClassList = function (elem) {
+    var
+        trimmedClasses = strTrim.call(elem.getAttribute("class") || "")
+      , classes = trimmedClasses ? trimmedClasses.split(/\s+/) : []
+      , i = 0
+      , len = classes.length
+    ;
+    for (; i < len; i++) {
+      this.push(classes[i]);
+    }
+    this._updateClassName = function () {
+      elem.setAttribute("class", this.toString());
+    };
+  }
+  , classListProto = ClassList[protoProp] = []
+  , classListGetter = function () {
+    return new ClassList(this);
+  }
+;
+// Most DOMException implementations don't allow calling DOMException's toString()
+// on non-DOMExceptions. Error's toString() is sufficient here.
+DOMEx[protoProp] = Error[protoProp];
+classListProto.item = function (i) {
+  return this[i] || null;
+};
+classListProto.contains = function (token) {
+  token += "";
+  return checkTokenAndGetIndex(this, token) !== -1;
+};
+classListProto.add = function () {
+  var
+      tokens = arguments
+    , i = 0
+    , l = tokens.length
+    , token
+    , updated = false
+  ;
+  do {
+    token = tokens[i] + "";
+    if (checkTokenAndGetIndex(this, token) === -1) {
+      this.push(token);
+      updated = true;
+    }
+  }
+  while (++i < l);
+
+  if (updated) {
+    this._updateClassName();
+  }
+};
+classListProto.remove = function () {
+  var
+      tokens = arguments
+    , i = 0
+    , l = tokens.length
+    , token
+    , updated = false
+    , index
+  ;
+  do {
+    token = tokens[i] + "";
+    index = checkTokenAndGetIndex(this, token);
+    while (index !== -1) {
+      this.splice(index, 1);
+      updated = true;
+      index = checkTokenAndGetIndex(this, token);
+    }
+  }
+  while (++i < l);
+
+  if (updated) {
+    this._updateClassName();
+  }
+};
+classListProto.toggle = function (token, force) {
+  token += "";
+
+  var
+      result = this.contains(token)
+    , method = result ?
+      force !== true && "remove"
+    :
+      force !== false && "add"
+  ;
+
+  if (method) {
+    this[method](token);
+  }
+
+  if (force === true || force === false) {
+    return force;
+  } else {
+    return !result;
+  }
+};
+classListProto.toString = function () {
+  return this.join(" ");
+};
+
+if (objCtr.defineProperty) {
+  var classListPropDesc = {
+      get: classListGetter
+    , enumerable: true
+    , configurable: true
+  };
+  try {
+    objCtr.defineProperty(elemCtrProto, classListProp, classListPropDesc);
+  } catch (ex) { // IE 8 doesn't support enumerable:true
+    if (ex.number === -0x7FF5EC54) {
+      classListPropDesc.enumerable = false;
+      objCtr.defineProperty(elemCtrProto, classListProp, classListPropDesc);
+    }
+  }
+} else if (objCtr[protoProp].__defineGetter__) {
+  elemCtrProto.__defineGetter__(classListProp, classListGetter);
+}
+
+}(self));
+
+} else {
+// There is full or partial native classList support, so just check if we need
+// to normalize the add/remove and toggle APIs.
+
+(function () {
+  "use strict";
+
+  var testElement = document.createElement("_");
+
+  testElement.classList.add("c1", "c2");
+
+  // Polyfill for IE 10/11 and Firefox <26, where classList.add and
+  // classList.remove exist but support only one argument at a time.
+  if (!testElement.classList.contains("c2")) {
+    var createMethod = function(method) {
+      var original = DOMTokenList.prototype[method];
+
+      DOMTokenList.prototype[method] = function(token) {
+        var i, len = arguments.length;
+
+        for (i = 0; i < len; i++) {
+          token = arguments[i];
+          original.call(this, token);
+        }
+      };
+    };
+    createMethod('add');
+    createMethod('remove');
+  }
+
+  testElement.classList.toggle("c3", false);
+
+  // Polyfill for IE 10 and Firefox <24, where classList.toggle does not
+  // support the second argument.
+  if (testElement.classList.contains("c3")) {
+    var _toggle = DOMTokenList.prototype.toggle;
+
+    DOMTokenList.prototype.toggle = function(token, force) {
+      if (1 in arguments && !this.contains(token) === !force) {
+        return force;
+      } else {
+        return _toggle.call(this, token);
+      }
+    };
+
+  }
+
+  testElement = null;
+}());
+
+}
+
+}
+} (window));


### PR DESCRIPTION
This is for issue #9 

Use the classList to add or remove classes makes the code cleaner.
Added polyfill javascript file for optional use of needed polyfilles.

[Array.prototype.forEach()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) is used for the custom class names.
Don't see the need to support IE8 and less.
Added comment in readme about what polyfill to use if legacy browser support is needed.
