### PR TITLE
Remove the mouseleaves event

### DIFF
--- a/jackbox.js
+++ b/jackbox.js
@@ -49,7 +49,10 @@
 
     var purge = function () {
       notification.classList.remove("show");
+      notification.removeEventListener('mouseleave', startCounter);
+
       window.clearTimeout(timeout);
+
       setTimeout(function () {
         document.getElementById("jackbox").removeChild(notification);
       }, 200);
@@ -65,7 +68,9 @@
         if (!notification.classList.contains("counting")){
           notification.classList.add("counting");
         }
-
+        if(timeout != null){
+          window.clearTimeout(timeout);
+        }
         timeout = window.setTimeout(purge, (ttl * 1000));
       }, 10);
     }


### PR DESCRIPTION
closes issue #13 
When deleting the element we trigger the 'mouseleave' event by animating down the notification.
Remove the event before deleting the element.
Clear timeouts before setting new one, otherwise we will have timeouts in the event loop running wild
